### PR TITLE
Update requirement for PyFxA

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-PyFxA==0.0.1
+PyFxA==0.0.5
 pytest-mozwebqa
 unittestzero

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except (OSError, IOError):
 deps = ['PyFxA==0.0.1']
 
 setup(name='fxapom',
-      version='1.0',
+      version='1.1',
       description="Mozilla Firefox Accounts Page Object Model",
       long_description=description,
       classifiers=[],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
`PyFxA` was updated to specify a minimum version of `requests`. This PR updates `fxapom` to use the latest version of `PyFxA`.

@davehunt r?