### PR TITLE
Allow for manually specifying the url to the API server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,10 @@
 language: python
-python:
-  - 2.6
-  - 2.7
 
-before_install:
-  - export DISPLAY=':99.0'
-  - sh -e /etc/init.d/xvfb start
+python: 2.7
 
 install: "pip install flake8"
 
-before_script: "flake8 . --ignore=E501"
-
-script: py.test --baseurl=https://123done-stable.dev.lcip.org/ --driver=firefox --webqatimeout=90 --destructive tests
+script: "flake8 ."
 
 notifications:
   email: webqa-ci@mozilla.org
-  irc: "irc.mozilla.org#mozwebqa"

--- a/fxapom/fxapom.py
+++ b/fxapom/fxapom.py
@@ -10,6 +10,11 @@ from fxa.core import Client
 from fxa.tests.utils import TestEmailAccount
 
 
+# Constants for available FxA environments
+DEV_URL = 'https://stable.dev.lcip.org/auth/'
+PROD_URL = 'https://api.accounts.firefox.com/'
+
+
 class WebDriverFxA(object):
 
     def __init__(self, testsetup):
@@ -27,21 +32,22 @@ class FxATestAccount:
 
     password = ''.join([random.choice(string.letters) for i in range(8)])
 
-    def __init__(self, base_url=None):
-        if base_url and '-dev.allizom' in base_url:
-            self.fxa_url = 'https://stable.dev.lcip.org/auth/'
-        else:
-            self.fxa_url = 'https://api.accounts.firefox.com/'
+    def __init__(self, url=DEV_URL):
+        """ Creates an FxATestAccount object.
+
+        :param url: The url for the api host. Defaults to DEV_URL.
+        """
+        self.url = url
 
     def create_account(self):
         random_string = ''.join(random.choice(string.ascii_lowercase) for _ in range(12))
         email_pattern = random_string + '@{hostname}'
         self.account = TestEmailAccount(email=email_pattern)
-        client = Client(self.fxa_url)
+        client = Client(self.url)
         # Create and verify the Firefox account
         self.session = client.create_account(self.account.email, self.password)
         print 'fxapom created an account for email: %s at %s on %s' % (
-            self.account.email, self.fxa_url, datetime.now())
+            self.account.email, self.url, datetime.now())
         m = self.account.wait_for_email(lambda m: "x-verify-code" in m["headers"])
         if not m:
             raise RuntimeError("Verification email was not received")

--- a/fxapom/pages/page.py
+++ b/fxapom/pages/page.py
@@ -7,8 +7,6 @@ import time
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import ElementNotVisibleException
-from selenium.common.exceptions import TimeoutException
-from unittestzero import Assert
 
 
 class Page(object):
@@ -86,7 +84,5 @@ class Page(object):
         try:
             WebDriverWait(self.selenium, self.timeout).until(lambda s: len(self.find_elements(*locator)) < 1)
             return True
-        except TimeoutException:
-            Assert.fail(TimeoutException)
         finally:
             self.selenium.implicitly_wait(self.testsetup.default_implicit_wait)

--- a/fxapom/pages/sign_in.py
+++ b/fxapom/pages/sign_in.py
@@ -71,5 +71,5 @@ class SignIn(Base):
         self.selenium.find_element(*self._sign_in_locator).click()
         if self.popup:
             WebDriverWait(self.selenium, self.timeout).until(
-                        lambda s: self._sign_in_window_handle not in self.selenium.window_handles)
+                lambda s: self._sign_in_window_handle not in self.selenium.window_handles)
             self.switch_to_main_window()

--- a/readme.md
+++ b/readme.md
@@ -13,13 +13,24 @@ as well as a set of page objects that can be used to interact with Firefox Accou
 Usage
 -----
 To create a test Firefox Account, use the `create_account` method in the `FxATestAccount` object.
-You should pass the base url for the site for which you are creating the account into the constructor
-for `FxATestAccount`, or, if you know you want to create a production Account, you can omit that argument.
+You can pass the url for the Firefox Accounts API server into the constructor
+or, if you know you want to create a development Account, you can omit that argument.
 
-Example:
+There are two constants available to you to specify the url for either the development environment
+or the production environment, which are:
+- `fxapom.DEV_URL` - the url for the development environment
+- `fxapom.PROD_URL` - the url for the production environment
+
+Example of creating an account on the development environment, using the default:
 ```python
 from fxapom.fxapom import FxATestAccount
-acct = FxATestAccount(base_url='https://www-dev.allizom.org').create_account()
+acct = FxATestAccount().create_account()
+```
+
+Example of creating an account on the development environment, specifying the `DEV_URL`:
+```python
+from fxapom.fxapom import DEV_URL, FxATestAccount
+acct = FxATestAccount(DEV_URL).create_account()
 ```
 
 To sign in via Firefox Accounts, use the `sign_in` method in the `WebDriverFxA` object,
@@ -41,9 +52,8 @@ To create an account and then use it to sign in, use both tools described above.
 
 Example:
 ```python
-from fxapom.fxapom import FxATestAccount
-from fxapom.fxapom import WebDriverFxA
-acct = FxATestAccount(base_url='https://www-dev.allizom.org').create_account()
+from fxapom.fxapom import FxATestAccount, WebDriverFxA
+acct = FxATestAccount().create_account()
 fxa = WebDriverFxA(mozwebqa)
 fxa.sign_in(acct.email, acct.password)
 ```
@@ -60,3 +70,23 @@ This software is licensed under the [MPL](http://www.mozilla.org/MPL/2.0/) 2.0:
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Change Log
+==========
+
+1.3
+---
+* Change FxATestAccount constructor to accept the url to the FxA API server
+  * This is a **breaking change**
+
+1.2
+---
+* Update required version of PyFxA in setup.py to 0.0.5
+
+1.1
+---
+* Update required version of PyFxA in requirements.txt to 0.0.5
+
+1.0
+---
+* Initial release

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-PyFxA==0.0.5
+PyFxA==0.0.6
 pytest-mozwebqa
-unittestzero

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+ignore=E501

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,12 @@
 from setuptools import setup, find_packages
-import os
-
-# get documentation from the README
-try:
-    here = os.path.dirname(os.path.abspath(__file__))
-    description = file(os.path.join(here, 'README.md')).read()
-except (OSError, IOError):
-    description = ''
 
 # dependencies
-deps = ['PyFxA==0.0.5']
+deps = ['PyFxA==0.0.6']
 
 setup(name='fxapom',
-      version='1.2',
+      version='1.3',
       description="Mozilla Firefox Accounts Page Object Model",
-      long_description=description,
+      long_description=open('README.md').read(),
       classifiers=[],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
       keywords='mozilla',
       author='Mozilla Web QA',

--- a/tests/test_create_account.py
+++ b/tests/test_create_account.py
@@ -4,26 +4,28 @@
 import re
 
 import pytest
-from unittestzero import Assert
 
-from fxapom.fxapom import FxATestAccount
+from fxapom.fxapom import DEV_URL, FxATestAccount, PROD_URL
 
 
-@pytest.mark.nondestructive
 @pytest.mark.skip_selenium
 class TestCreateAccount(object):
 
-    def test_create_new_account_on_dev(self):
-        acct = FxATestAccount(base_url='https://www-dev.allizom.org').create_account()
-        Assert.true(acct.is_verified)
-        Assert.equal('https://stable.dev.lcip.org/auth/', acct.fxa_url)
+    def test_default_environment_should_be_dev(self):
+        acct = FxATestAccount()
+        assert DEV_URL == acct.url
 
-    def test_create_new_account_on_stage(self):
-        acct = FxATestAccount(base_url='https://www.allizom.org').create_account()
-        Assert.true(acct.is_verified)
-        Assert.equal('https://api.accounts.firefox.com/', acct.fxa_url)
+    def test_create_new_account_on_dev(self):
+        acct = FxATestAccount(DEV_URL).create_account()
+        assert acct.is_verified
+        assert DEV_URL == acct.url
+
+    def test_create_new_account_on_prod(self):
+        acct = FxATestAccount(PROD_URL).create_account()
+        assert acct.is_verified
+        assert PROD_URL == acct.url
 
     def test_new_account_pw_does_not_contain_numbers(self):
-        acct = FxATestAccount(base_url='https://www-dev.allizom.org').create_account()
+        acct = FxATestAccount().create_account()
         test_regex = re.compile('\d')
-        Assert.equal(None, test_regex.search(acct.password))
+        assert test_regex.search(acct.password) is None

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -5,8 +5,7 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 
-from fxapom.fxapom import FxATestAccount
-from fxapom.fxapom import WebDriverFxA
+from fxapom.fxapom import FxATestAccount, WebDriverFxA
 
 
 class TestLogin(object):
@@ -14,7 +13,7 @@ class TestLogin(object):
     _fxa_logged_in_indicator_locator = (By.ID, 'loggedin')
 
     def test_user_can_sign_in(self, mozwebqa):
-        acct = FxATestAccount(base_url='https://www-dev.allizom.org').create_account()
+        acct = FxATestAccount().create_account()
         fxa = WebDriverFxA(mozwebqa)
         fxa.sign_in(acct.email, acct.password)
         WebDriverWait(mozwebqa.selenium, mozwebqa.timeout).until(


### PR DESCRIPTION
Remove unittestzero and switch to native asserts
Update readme to reflect new usage
Update pyfxa requirement to latest version
Update Travis config to only run flake8 check