### PR TITLE
Migrate fxapom to pytest-selenium

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,14 +8,19 @@ from selenium.webdriver.support.ui import WebDriverWait
 from fxapom.fxapom import DEV_URL, FxATestAccount, PROD_URL
 
 
-def pytest_funcarg__mozwebqa(request):
+@pytest.fixture(scope='session')
+def capabilities(capabilities):
+    capabilities.setdefault('tags', []).append('fxapom')
+    return capabilities
+
+
+@pytest.fixture
+def click_login(base_url, selenium):
     fxa_login_button_locator_css = 'button.signin'
-    mozwebqa = request.getfuncargvalue('mozwebqa')
-    mozwebqa.selenium.get('%s/' % mozwebqa.base_url)
-    WebDriverWait(mozwebqa.selenium, mozwebqa.timeout).until(
+    selenium.get('%s/' % base_url)
+    WebDriverWait(selenium, 10).until(
         lambda s: s.find_element_by_css_selector(fxa_login_button_locator_css).is_displayed())
-    mozwebqa.selenium.find_element_by_css_selector(fxa_login_button_locator_css).click()
-    return mozwebqa
+    selenium.find_element_by_css_selector(fxa_login_button_locator_css).click()
 
 
 @pytest.fixture(params=[DEV_URL, PROD_URL])

--- a/fxapom/fxapom.py
+++ b/fxapom/fxapom.py
@@ -21,13 +21,14 @@ class AccountNotFoundException(Exception):
 
 class WebDriverFxA(object):
 
-    def __init__(self, testsetup):
-        self.testsetup = testsetup
+    def __init__(self, base_url, selenium):
+        self.base_url = base_url
+        self.selenium = selenium
 
     def sign_in(self, email=None, password=None):
         """Signs in a user, either with the specified email address and password, or a returning user."""
         from pages.sign_in import SignIn
-        sign_in = SignIn(self.testsetup)
+        sign_in = SignIn(self.base_url, self.selenium)
         sign_in.sign_in(email, password)
 
 

--- a/fxapom/pages/base.py
+++ b/fxapom/pages/base.py
@@ -6,8 +6,8 @@ from page import Page
 
 class Base(Page):
 
-    def __init__(self, testsetup):
-        super(Base, self).__init__(testsetup)
+    def __init__(self, base_url, selenium):
+        super(Base, self).__init__(base_url, selenium)
         self._main_window_handle = self.selenium.current_window_handle
 
     def switch_to_main_window(self):

--- a/fxapom/pages/page.py
+++ b/fxapom/pages/page.py
@@ -9,16 +9,15 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import ElementNotVisibleException
 
 
+TIMEOUT = 10
+
+
 class Page(object):
-    """Base class for all Pages"""
 
-    def __init__(self, testsetup):
-        """Constructor"""
-
-        self.testsetup = testsetup
-        self.base_url = testsetup.base_url
-        self.selenium = testsetup.selenium
-        self.timeout = testsetup.timeout
+    def __init__(self, base_url, selenium):
+        self.base_url = base_url
+        self.selenium = selenium
+        self.timeout = TIMEOUT
         self._selenium_root = hasattr(self, '_root_element') and self._root_element or self.selenium
 
     def is_element_present(self, *locator):
@@ -34,7 +33,7 @@ class Page(object):
             return False
         finally:
             # set the implicit wait back
-            self.selenium.implicitly_wait(self.testsetup.default_implicit_wait)
+            self.selenium.implicitly_wait(self.timeout)
 
     def is_element_visible(self, *locator):
         """
@@ -58,7 +57,7 @@ class Page(object):
             return True
         finally:
             # set the implicit wait back
-            self.selenium.implicitly_wait(self.testsetup.default_implicit_wait)
+            self.selenium.implicitly_wait(self.timeout)
 
     def wait_for_element_present(self, *locator):
         """Wait for the element at the specified locator to be present in the DOM."""
@@ -85,4 +84,4 @@ class Page(object):
             WebDriverWait(self.selenium, self.timeout).until(lambda s: len(self.find_elements(*locator)) < 1)
             return True
         finally:
-            self.selenium.implicitly_wait(self.testsetup.default_implicit_wait)
+            self.selenium.implicitly_wait(self.timeout)

--- a/fxapom/pages/sign_in.py
+++ b/fxapom/pages/sign_in.py
@@ -5,6 +5,7 @@
 from base import Base
 
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 
@@ -16,8 +17,8 @@ class SignIn(Base):
     _password_input_locator = (By.ID, 'password')
     _sign_in_locator = (By.ID, 'submit-btn')
 
-    def __init__(self, testsetup):
-        Base.__init__(self, testsetup)
+    def __init__(self, base_url, selenium):
+        Base.__init__(self, base_url, selenium)
 
         if len(self.selenium.window_handles) > 1:
             self.popup = True
@@ -48,7 +49,8 @@ class SignIn(Base):
     @email.setter
     def email(self, value):
         """Set the value of the email field."""
-        email = self.selenium.find_element(*self._email_input_locator)
+        email = WebDriverWait(self.selenium, self.timeout).until(
+            EC.visibility_of_element_located(self._email_input_locator))
         email.clear()
         email.send_keys(value)
 

--- a/mozwebqa.cfg
+++ b/mozwebqa.cfg
@@ -1,3 +1,0 @@
-[DEFAULT]
-baseurl = https://123done-stable.dev.lcip.org/
-tags = fxapom

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [flake8]
 ignore=E501
+
+[pytest]
+base_url=https://123done-stable.dev.lcip.org
+sensitive_url=mozilla\.(com|org)

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setup(name='fxapom',
       url='https://github.com/mozilla/fxapom',
       license='MPL 2.0',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-      install_requires=['PyFxA==0.0.6'],
+      install_requires=['PyFxA==0.0.8'],
       include_package_data=True)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
-pytest==2.7.2
-pytest-mozwebqa
+pytest==2.7.3
+pytest-selenium

--- a/tests/test_fxa_test_account.py
+++ b/tests/test_fxa_test_account.py
@@ -4,7 +4,6 @@
 
 import re
 
-import pytest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -15,22 +14,19 @@ class TestFxATestAccount(object):
 
     _fxa_unknown_account_error_locator = (By.CSS_SELECTOR, '#main-content div.error')
 
-    @pytest.mark.skip_selenium
     def test_default_environment_should_be_dev(self):
         account = FxATestAccount()
         assert DEV_URL == account.url
 
-    @pytest.mark.skip_selenium
     def test_create_new_account(self, account):
         assert account.is_verified
         # Test logging in - will throw an exception if log in fails
         account.login()
 
-    @pytest.mark.skip_selenium
     def test_new_account_pw_does_not_contain_numbers(self, account):
         assert re.search(r'\d', account.password) is None
 
-    def test_del(self, mozwebqa):
+    def test_del(self, base_url, selenium, click_login):
         """ Check that the __del__ method does destroy the FxA """
         account = FxATestAccount()
         email = account.email
@@ -40,8 +36,8 @@ class TestFxATestAccount(object):
         del account
 
         # try to log in
-        fxa = WebDriverFxA(mozwebqa)
+        fxa = WebDriverFxA(base_url, selenium)
         fxa.sign_in(email, password)
-        WebDriverWait(mozwebqa.selenium, mozwebqa.timeout).until(
+        WebDriverWait(selenium, 10).until(
             lambda s: s.find_element(*self._fxa_unknown_account_error_locator).is_displayed())
-        assert 'Unknown account' in mozwebqa.selenium.find_element(*self._fxa_unknown_account_error_locator).text
+        assert 'Unknown account' in selenium.find_element(*self._fxa_unknown_account_error_locator).text

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -12,8 +12,8 @@ class TestLogin(object):
 
     _fxa_logged_in_indicator_locator = (By.ID, 'loggedin')
 
-    def test_user_can_sign_in(self, mozwebqa, dev_account):
-        fxa = WebDriverFxA(mozwebqa)
+    def test_user_can_sign_in(self, base_url, selenium, dev_account, click_login):
+        fxa = WebDriverFxA(base_url, selenium)
         fxa.sign_in(dev_account.email, dev_account.password)
-        WebDriverWait(mozwebqa.selenium, mozwebqa.timeout).until(
+        WebDriverWait(selenium, 20).until(
             lambda s: s.find_element(*self._fxa_logged_in_indicator_locator).is_displayed())


### PR DESCRIPTION
It looks like I may need to make some changes to FxAPom to support a new test for Markteplace, so I decided to do some cleanup first. Step 1 is to migrate to pytest-selenium, after which I will also remove all implicit waits as well as clean up the page objects a bit more.

I had to add one explicit wait after switching to pytest-selenium to allow the tests to pass.

There is an adhoc scheduled at http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/fxapom.adhoc.pytest-selenium/, but it's currently at the end of a long queue.

@mozilla/web-qa-sorcerers @davehunt r?