### PR TITLE
Remove implicit waits and clean up page objects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,12 @@ Running The Tests
 Change Log
 ----------
 
+1.5
+^^^
+
+* Switch the test suite to use ``pytest-selenium``
+* Remove implicit waits from the tests and page objects
+
 1.4
 ^^^
 

--- a/conftest.py
+++ b/conftest.py
@@ -3,9 +3,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support.ui import WebDriverWait as Wait
 
-from fxapom.fxapom import DEV_URL, FxATestAccount, PROD_URL
+from fxapom.fxapom import DEV_URL, FxATestAccount, PROD_URL, TIMEOUT
 
 
 @pytest.fixture(scope='session')
@@ -14,20 +14,25 @@ def capabilities(capabilities):
     return capabilities
 
 
-@pytest.fixture
-def click_login(base_url, selenium):
-    fxa_login_button_locator_css = 'button.signin'
-    selenium.get('%s/' % base_url)
-    WebDriverWait(selenium, 10).until(
-        lambda s: s.find_element_by_css_selector(fxa_login_button_locator_css).is_displayed())
-    selenium.find_element_by_css_selector(fxa_login_button_locator_css).click()
-
-
 @pytest.fixture(params=[DEV_URL, PROD_URL])
 def account(request):
     return FxATestAccount(request.param)
 
 
 @pytest.fixture
+def click_login(base_url, selenium, timeout):
+    fxa_login_button_locator_css = 'button.signin'
+    selenium.get('%s/' % base_url)
+    Wait(selenium, timeout).until(
+        lambda s: s.find_element_by_css_selector(fxa_login_button_locator_css).is_displayed())
+    selenium.find_element_by_css_selector(fxa_login_button_locator_css).click()
+
+
+@pytest.fixture
 def dev_account():
     return FxATestAccount(DEV_URL)
+
+
+@pytest.fixture
+def timeout():
+    return TIMEOUT

--- a/fxapom/fxapom.py
+++ b/fxapom/fxapom.py
@@ -14,6 +14,8 @@ from fxa.tests.utils import TestEmailAccount
 DEV_URL = 'https://stable.dev.lcip.org/auth/'
 PROD_URL = 'https://api.accounts.firefox.com/'
 
+TIMEOUT = 20
+
 
 class AccountNotFoundException(Exception):
     pass
@@ -21,14 +23,15 @@ class AccountNotFoundException(Exception):
 
 class WebDriverFxA(object):
 
-    def __init__(self, base_url, selenium):
+    def __init__(self, base_url, selenium, timeout=TIMEOUT):
         self.base_url = base_url
         self.selenium = selenium
+        self.timeout = timeout
 
     def sign_in(self, email=None, password=None):
         """Signs in a user, either with the specified email address and password, or a returning user."""
         from pages.sign_in import SignIn
-        sign_in = SignIn(self.base_url, self.selenium)
+        sign_in = SignIn(self.base_url, self.selenium, self.timeout)
         sign_in.sign_in(email, password)
 
 

--- a/fxapom/pages/base.py
+++ b/fxapom/pages/base.py
@@ -1,13 +1,15 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from ..fxapom import TIMEOUT
 from page import Page
 
 
 class Base(Page):
 
-    def __init__(self, base_url, selenium):
-        super(Base, self).__init__(base_url, selenium)
+    def __init__(self, base_url, selenium, timeout=TIMEOUT):
+        super(Base, self).__init__(base_url, selenium, timeout)
         self._main_window_handle = self.selenium.current_window_handle
 
     def switch_to_main_window(self):

--- a/fxapom/pages/page.py
+++ b/fxapom/pages/page.py
@@ -2,86 +2,21 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import time
-
-from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import NoSuchElementException
-from selenium.common.exceptions import ElementNotVisibleException
 
-
-TIMEOUT = 10
+from ..fxapom import TIMEOUT
 
 
 class Page(object):
 
-    def __init__(self, base_url, selenium):
+    def __init__(self, base_url, selenium, timeout=TIMEOUT):
         self.base_url = base_url
         self.selenium = selenium
-        self.timeout = TIMEOUT
+        self.timeout = timeout
         self._selenium_root = hasattr(self, '_root_element') and self._root_element or self.selenium
 
-    def is_element_present(self, *locator):
-        """
-        Return true if the element at the specified locator is present in the DOM.
-        Note: It returns false immediately if the element is not found.
-        """
-        self.selenium.implicitly_wait(0)
-        try:
-            self._selenium_root.find_element(*locator)
-            return True
-        except NoSuchElementException:
-            return False
-        finally:
-            # set the implicit wait back
-            self.selenium.implicitly_wait(self.timeout)
-
     def is_element_visible(self, *locator):
-        """
-        Return true if the element at the specified locator is visible in the browser.
-        Note: It uses an implicit wait if it cannot find the element immediately.
-        """
         try:
             return self._selenium_root.find_element(*locator).is_displayed()
-        except (NoSuchElementException, ElementNotVisibleException):
+        except (NoSuchElementException,):
             return False
-
-    def is_element_not_visible(self, *locator):
-        """
-        Return true if the element at the specified locator is not visible in the browser.
-        Note: It returns true immediately if the element is not found.
-        """
-        self.selenium.implicitly_wait(0)
-        try:
-            return not self._selenium_root.find_element(*locator).is_displayed()
-        except (NoSuchElementException, ElementNotVisibleException):
-            return True
-        finally:
-            # set the implicit wait back
-            self.selenium.implicitly_wait(self.timeout)
-
-    def wait_for_element_present(self, *locator):
-        """Wait for the element at the specified locator to be present in the DOM."""
-        count = 0
-        while not self.is_element_present(*locator):
-            time.sleep(1)
-            count += 1
-            if count == self.timeout:
-                raise Exception(*locator + ' has not loaded')
-
-    def wait_for_element_visible(self, *locator):
-        """Wait for the element at the specified locator to be visible in the browser."""
-        count = 0
-        while not self.is_element_visible(*locator):
-            time.sleep(1)
-            count += 1
-            if count == self.timeout:
-                raise Exception(*locator + ' is not visible')
-
-    def wait_for_element_not_present(self, *locator):
-        """Wait for the element at the specified locator to be not present in the DOM."""
-        self.selenium.implicitly_wait(0)
-        try:
-            WebDriverWait(self.selenium, self.timeout).until(lambda s: len(self.find_elements(*locator)) < 1)
-            return True
-        finally:
-            self.selenium.implicitly_wait(self.timeout)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='fxapom',
-      version='1.4',
+      version='1.5',
       description='Mozilla Firefox Accounts Page Object Model',
       long_description=open('README.rst').read(),
       classifiers=[

--- a/tests/test_fxa_test_account.py
+++ b/tests/test_fxa_test_account.py
@@ -5,7 +5,8 @@
 import re
 
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait as Wait
 
 from fxapom.fxapom import DEV_URL, FxATestAccount, WebDriverFxA
 
@@ -26,7 +27,7 @@ class TestFxATestAccount(object):
     def test_new_account_pw_does_not_contain_numbers(self, account):
         assert re.search(r'\d', account.password) is None
 
-    def test_del(self, base_url, selenium, click_login):
+    def test_del(self, base_url, selenium, click_login, timeout):
         """ Check that the __del__ method does destroy the FxA """
         account = FxATestAccount()
         email = account.email
@@ -38,6 +39,6 @@ class TestFxATestAccount(object):
         # try to log in
         fxa = WebDriverFxA(base_url, selenium)
         fxa.sign_in(email, password)
-        WebDriverWait(selenium, 10).until(
-            lambda s: s.find_element(*self._fxa_unknown_account_error_locator).is_displayed())
-        assert 'Unknown account' in selenium.find_element(*self._fxa_unknown_account_error_locator).text
+        el = Wait(selenium, timeout).until(
+            EC.visibility_of_element_located(self._fxa_unknown_account_error_locator))
+        assert 'Unknown account' in el.text

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -3,7 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait as Wait
 
 from fxapom.fxapom import WebDriverFxA
 
@@ -12,8 +13,9 @@ class TestLogin(object):
 
     _fxa_logged_in_indicator_locator = (By.ID, 'loggedin')
 
-    def test_user_can_sign_in(self, base_url, selenium, dev_account, click_login):
-        fxa = WebDriverFxA(base_url, selenium)
+    def test_user_can_sign_in(self, base_url, selenium, dev_account, click_login, timeout):
+        fxa = WebDriverFxA(base_url, selenium, timeout)
         fxa.sign_in(dev_account.email, dev_account.password)
-        WebDriverWait(selenium, 20).until(
-            lambda s: s.find_element(*self._fxa_logged_in_indicator_locator).is_displayed())
+        # We sometimes need to wait longer than the standard 10 seconds
+        Wait(selenium, timeout).until(
+            EC.visibility_of_element_located(self._fxa_logged_in_indicator_locator))


### PR DESCRIPTION
Also introduced a `timeout` fixture to centralize the setting of the default timeout

Adhoc at http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/fxapom.adhoc/5/

@mozilla/web-qa-sorcerers r?