### PR TITLE
Upgrade PyFxA to 0.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setup(name='fxapom',
       url='https://github.com/mozilla/fxapom',
       license='MPL 2.0',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-      install_requires=['PyFxA==0.0.8'],
+      install_requires=['PyFxA==0.1.1'],
       include_package_data=True)


### PR DESCRIPTION
`(fxapom) sdonners-MacBook-Pro:fxapom sdonner$ py.test --base-url https://123done-stable.dev.lcip.org --driver=Firefox --bin=/Applications/Firefox.app/Contents/MacOS/firefox-bin tests
====================================================== test session starts ======================================================
platform darwin -- Python 2.7.11, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /Users/sdonner/fxapom, inifile: setup.cfg
plugins: html-1.8.0, selenium-1.2.1, variables-1.4, xdist-1.14
collected 11 items 

tests/test_fxa_test_account.py ..fxapom deleted the account for email: pffpkwnydmsc@restmail.net at https://stable.dev.lcip.org/auth/ on 2016-03-31 10:29:59.747246
.fxapom deleted the account for email: xsoidxyfpacn@restmail.net at https://api.accounts.firefox.com/ on 2016-03-31 10:30:03.970881
.fxapom deleted the account for email: mbrjkljodmfg@restmail.net at https://stable.dev.lcip.org/auth/ on 2016-03-31 10:30:07.119698
.fxapom deleted the account for email: ypmrbtuivajm@restmail.net at https://api.accounts.firefox.com/ on 2016-03-31 10:30:09.188221
.
tests/test_fxapom.py ...
tests/marionette/test_fxa_login.py .
tests/webdriver/test_fxa_login.py .fxapom deleted the account for email: wzgrzphfxzvj@restmail.net at https://stable.dev.lcip.org/auth/ on 2016-03-31 10:30:33.438978


================================================== 11 passed in 42.33 seconds ===================================================`