### PR TITLE
Switch tests to Tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
+__pycache__
+.cache
+.tox
 build
 dist
 .idea/
 *.pyc
 fxapom.egg-info
+results/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
 language: python
 python: 2.7
 addons:
-  firefox: "latest"
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
+  firefox: latest
+env:
+  - TOXENV=tests DISPLAY=:99.0
+  - TOXENV=flake8
 install:
-  - pip install flake8
-  - pip install -r tests/requirements.txt
+  - pip install tox
+before_script:
+  - sh -e /etc/init.d/xvfb start
 script:
-  - flake8 .
-  - python setup.py install
-  - py.test -r a -v --driver Firefox tests
+  - tox
 notifications:
   email: webqa-ci@mozilla.org

--- a/README.rst
+++ b/README.rst
@@ -92,8 +92,8 @@ To create an account and then use it to sign in, use both tools described above:
 Running The Tests
 -----------------
 
-* Install the requirements using ``pip install -r requirements.txt``
-* Run the tests using a local Firefox browser via ``py.test --driver=Firefox tests``
+* `Install Tox <http://tox.readthedocs.io/en/latest/install.html>`_
+* Run ``tox``
 
 Resources
 ---------

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,8 @@
 ignore=E501
 
 [pytest]
+addopts=-n=auto --verbose -r=a --driver=Firefox --junit-xml=results/junit.xml --html=results/index.html
+testpaths=tests
+xfail_strict=true
 base_url=https://123done-stable.dev.lcip.org
 sensitive_url=mozilla\.(com|org)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,0 @@
-marionette_driver==2.0.0
-mock
-pytest==2.9.2
-pytest-selenium
-pytest-xdist==1.14

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = tests, flake8
+
+[testenv]
+passenv = DISPLAY PYTEST_ADDOPTS
+deps =
+    marionette_driver==2.0.0
+    mock
+    pytest==2.9.2
+    pytest-selenium
+    pytest-xdist==1.14
+commands = py.test {posargs}
+
+[testenv:flake8]
+skip_install = true
+deps = flake8
+commands = flake8 {posargs:.}


### PR DESCRIPTION
Switch the tests to use Tox for improved management of virtual environments - it also makes it easier to test support for multiple Python versions in the future. After merging we will need to update Jenkins to use Tox.