### PR TITLE
Switch to email-ext for Jenkins notifications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,6 +59,7 @@ pipeline {
     failure {
       emailext(
         attachLog: true,
+        attachmentsPattern: 'results/py27.html',
         body: '$BUILD_URL\n\n$FAILED_TESTS',
         replyTo: '$DEFAULT_REPLYTO',
         subject: '$DEFAULT_SUBJECT',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,8 @@ pipeline {
   post {
     failure {
       emailext(
-        body: '$BUILD_URL\n\n$FAILED_TESTS\n\n$BUILD_LOG',
+        attachLog: true,
+        body: '$BUILD_URL\n\n$FAILED_TESTS',
         replyTo: '$DEFAULT_REPLYTO',
         subject: '$DEFAULT_SUBJECT',
         to: '$DEFAULT_RECIPIENTS')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,12 +57,11 @@ pipeline {
   }
   post {
     failure {
-      mail(
-        body: "${BUILD_URL}",
-        from: "firefox-test-engineering@mozilla.com",
-        replyTo: "firefox-test-engineering@mozilla.com",
-        subject: "Build failed in Jenkins: ${JOB_NAME} #${BUILD_NUMBER}",
-        to: "fte-ci@mozilla.com")
+      emailext(
+        body: '$BUILD_URL\n\n$FAILED_TESTS\n\n$BUILD_LOG',
+        replyTo: '$DEFAULT_REPLYTO',
+        subject: '$DEFAULT_SUBJECT',
+        to: '$DEFAULT_RECIPIENTS')
     }
     changed {
       ircNotification()


### PR DESCRIPTION
This switches our email notifications to use the email-ext plugin, which allows us to include details of failed tests and the build log in the body. This requires the following for all Jenkins instances:

* Email-ext plugin installed
  * [X] qa-preprod-master.fxtest.jenkins.stage.mozaws.net
  * [ ] fx-test-jenkins.stage.mozaws.net
  * [ ] qa-master.fxtest.jenkins.stage.mozaws.net
* Default reply-to configured
  * [X] qa-preprod-master.fxtest.jenkins.stage.mozaws.net
  * [ ] fx-test-jenkins.stage.mozaws.net
  * [ ] qa-master.fxtest.jenkins.stage.mozaws.net
* Default recipients configured
  * [X] qa-preprod-master.fxtest.jenkins.stage.mozaws.net
  * [ ] fx-test-jenkins.stage.mozaws.net
  * [ ] qa-master.fxtest.jenkins.stage.mozaws.net