### PR TITLE
Set number of pytest processes via environment variable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,9 @@ pipeline {
     timeout(time: 1, unit: 'HOURS')
   }
   environment {
+    PYTEST_PROCESSES = "${PYTEST_PROCESSES ?: "auto"}"
     PYTEST_ADDOPTS =
-      "-n=10 " +
+      "-n=${PYTEST_PROCESSES} " +
       "--tb=short " +
       "--color=yes " +
       "--driver=SauceLabs " +


### PR DESCRIPTION
This works well now that we're on v1.2.2 of [Pipeline Model Definition](https://plugins.jenkins.io/pipeline-model-definition). This means the number of processes will default to 'auto', but we will be able to experiment with overriding this on the Jenkins instance.