### PR TITLE
Simplify the way we store Sauce Labs credentials

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
       "--log-raw=results/py27_raw.txt " +
       "--log-tbpl=results/py27_tbpl.txt"
     PULSE = credentials('PULSE')
-    SAUCELABS_API_KEY = credentials('SAUCELABS_API_KEY')
+    SAUCELABS = credentials('SAUCELABS')
   }
   stages {
     stage('Lint') {

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist = py{27,36}, flake8
 
 [testenv]
-passenv = DISPLAY PYTEST_ADDOPTS PYTEST_BASE_URL SAUCELABS_API_KEY \
-    SAUCELABS_USERNAME JENKINS_URL JOB_NAME BUILD_NUMBER
+passenv = DISPLAY PYTEST_ADDOPTS PYTEST_BASE_URL SAUCELABS_USR SAUCELABS_PSW \
+    JENKINS_URL JOB_NAME BUILD_NUMBER
 deps = -rrequirements/{envname}-tests.txt
 commands = pytest \
     --junit-xml=results/{envname}.xml \

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist = py{27,36}, flake8
 
 [testenv]
 passenv = BUILD_NUMBER DISPLAY GIT_BRANCH GIT_COMMIT GIT_URL JENKINS_URL \
-    JOB_NAME PYTEST_ADDOPTS PYTEST_BASE_URL SAUCELABS_API_KEY \
-    SAUCELABS_USERNAME
+    JOB_NAME PYTEST_ADDOPTS PYTEST_BASE_URL SAUCELABS_USR \
+    SAUCELABS_PSW
 deps = -rrequirements/{envname}-tests.txt
 commands = pytest \
     --junit-xml=results/{envname}.xml \


### PR DESCRIPTION
The pytest-selenium plugin supports the way user/password credentials are stored in Jenkins so we can simplify our Jenkins configuration. Currently we have the API key stored as a string credential, and the username as an environment variable. With this change we can use a user/password type of credential named simply 'SAUCELABS'.

Before we can merge this we will need the new credential to be configured on:
* [ ] qa-master.fxtest.jenkins.stage.mozaws.net
* [x] qa-preprod-master.fxtest.jenkins.stage.mozaws.net
* [ ] fx-test-jenkins.stage.mozaws.net (unless it's decommissioned in the meantime)

Note that we should not delete the SAUCELABS_API_KEY credential or SAUCELABS_USERNAME environment variable until there are no pipelines depending on these.