### PR TITLE
Use a docker image to run the tests 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.cache
+.tox
+**/__pycache__
+**/*.pyc
+build
+dist
+fxapom.egg-info
+results

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 __pycache__
 .cache
+.eggs
+.idea/
 .tox
+*.pyc
 build
 dist
-.idea/
-*.pyc
 fxapom.egg-info
 results/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,32 @@
+sudo: required
 language: python
-python:
-  - 2.7
-  - 3.6
-addons:
-  firefox: latest
-env:
-  global:
-    - DISPLAY=:99.0
-matrix:
+services:
+  - docker
+jobs:
   include:
-    - python: 2.7
+    - stage:
       env: TOXENV=flake8
-    - python: 2.7
+    - stage:
       env: TOXENV=py27
-    - python: 3.6
-      env: TOXENV=flake8
-    - python: 3.6
+    - stage:
       env: TOXENV=py36
-  exclude:
-    - python: 2.7
-    - python: 3.6
-before_install:
-  - wget -O geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz
-  - gunzip -c geckodriver.tar.gz | tar xopf -
-  - chmod +x geckodriver && sudo mv geckodriver /usr/local/bin
-  - firefox --version
-  - geckodriver --version
-install:
-  - pip install tox
-before_script:
-  - sh -e /etc/init.d/xvfb start
-script:
-  - tox
+    - stage: deploy
+      python: 3.6
+      before_install: skip
+      script: skip
+      deploy:
+        provider: pypi
+        user: davehunt
+        password:
+          secure: GyTB/x+/F1DNmAWF4K8keaBgwUTq6AVgCfdMzArPSLiHxs4Fi98Y44U6YM4fy5qwZ8oJxYYwdlWoooStIYouV8PEg0GOl+x1m7eb02XXZEufVUqQ4p5sN3HHeUmj2Et0j0o0AkUvAZjY2zCS3hI9U8wH+rLrkyR/1g8a88HLeHo=
+        distributions: sdist bdist_wheel
+        on:
+          tags: true
+          repo: mozilla/fxapom
+cache:
+  pip: true
+before_install: docker build -t mozilla/fxapom .
+install: skip
+script: docker run -e TOXENV=$TOXENV mozilla/fxapom tox
 notifications:
   email: fte-ci@mozilla.com
-deploy:
-  provider: pypi
-  user: davehunt
-  password:
-    secure: GyTB/x+/F1DNmAWF4K8keaBgwUTq6AVgCfdMzArPSLiHxs4Fi98Y44U6YM4fy5qwZ8oJxYYwdlWoooStIYouV8PEg0GOl+x1m7eb02XXZEufVUqQ4p5sN3HHeUmj2Et0j0o0AkUvAZjY2zCS3hI9U8wH+rLrkyR/1g8a88HLeHo=
-  distributions: sdist bdist_wheel
-  on:
-    tags: true
-    repo: mozilla/fxapom
-    python: 2.7
-    condition: "$TOXENV = py27"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,20 @@
-FROM ubuntu:trusty
+FROM alpine:latest
 
-ENV DEBIAN_FRONTEND=noninteractive \
-    MOZ_HEADLESS=1
+ENV MOZ_HEADLESS=1
 
-RUN gpg --keyserver keyserver.ubuntu.com --recv-keys DB82666C \
- && gpg --export DB82666C | apt-key add -
-
-RUN echo deb http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu trusty main >> /etc/apt/sources.list \
- && echo deb-src http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu trusty main >> /etc/apt/sources.list
-
-RUN apt-get update \
- && apt-get install -y \
-    git \
+RUN mkdir /opt
+RUN echo @testing http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
+RUN apk --no-cache add \
     curl \
-    firefox \
-    python2.7-dev \
-    python3.6-dev \
- && rm -rf /var/lib/apt/lists/*
-
-RUN curl -fsSL https://bootstrap.pypa.io/get-pip.py | python2.7
-
-ENV FIREFOX_VERSION=57.0b14
-RUN curl -fsSLo /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
-  && apt-get -y purge firefox \
-  && rm -rf /opt/firefox \
-  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
-  && rm /tmp/firefox.tar.bz2 \
-  && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
-&& ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
+    firefox@testing \
+    gcc \
+    git \
+    libffi-dev \
+    musl-dev \
+    openssl-dev \
+    py3-pip \
+    python2-dev \
+    python3-dev
 
 ENV GECKODRIVER_VERSION=0.19.1
 RUN curl -fsSLo /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz \
@@ -38,8 +25,8 @@ RUN curl -fsSLo /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/r
   && chmod 755 /opt/geckodriver-$GECKODRIVER_VERSION \
 && ln -fs /opt/geckodriver-$GECKODRIVER_VERSION /usr/bin/geckodriver
 
-ENV TOX_VERSION=2.3.1
-RUN pip install tox==$TOX_VERSION
+ENV TOX_VERSION=2.9.1
+RUN pip3 install tox==$TOX_VERSION
 
 ADD . /src
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:trusty
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    MOZ_HEADLESS=1
+
+RUN gpg --keyserver keyserver.ubuntu.com --recv-keys DB82666C \
+ && gpg --export DB82666C | apt-key add -
+
+RUN echo deb http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu trusty main >> /etc/apt/sources.list \
+ && echo deb-src http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu trusty main >> /etc/apt/sources.list
+
+RUN apt-get update \
+ && apt-get install -y \
+    git \
+    curl \
+    firefox \
+    python2.7-dev \
+    python3.6-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://bootstrap.pypa.io/get-pip.py | python2.7
+
+ENV FIREFOX_VERSION=57.0b14
+RUN curl -fsSLo /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
+  && apt-get -y purge firefox \
+  && rm -rf /opt/firefox \
+  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
+  && rm /tmp/firefox.tar.bz2 \
+  && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
+&& ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
+
+ENV GECKODRIVER_VERSION=0.19.1
+RUN curl -fsSLo /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz \
+  && rm -rf /opt/geckodriver \
+  && tar -C /opt -zxf /tmp/geckodriver.tar.gz \
+  && rm /tmp/geckodriver.tar.gz \
+  && mv /opt/geckodriver /opt/geckodriver-$GECKODRIVER_VERSION \
+  && chmod 755 /opt/geckodriver-$GECKODRIVER_VERSION \
+&& ln -fs /opt/geckodriver-$GECKODRIVER_VERSION /usr/bin/geckodriver
+
+ENV TOX_VERSION=2.3.1
+RUN pip install tox==$TOX_VERSION
+
+ADD . /src
+WORKDIR /src

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,9 +6,7 @@ def capabilities = [
 ]
 
 pipeline {
-  agent {
-    dockerfile true
-  }
+  agent any
   libraries {
     lib('fxtest@1.9')
   }
@@ -24,52 +22,81 @@ pipeline {
       "--tb=short " +
       "--color=yes " +
       "--driver=SauceLabs " +
-      "--variables=capabilities.json " +
-      "--log-raw=results/py27_raw.txt " +
-      "--log-tbpl=results/py27_tbpl.txt"
+      "--variables=capabilities.json"
     PULSE = credentials('PULSE')
     SAUCELABS = credentials('SAUCELABS')
   }
   stages {
     stage('Lint') {
+      agent {
+        dockerfile true
+      }
       steps {
         sh "tox -e flake8"
       }
     }
     stage('Test') {
-      steps {
-        writeCapabilities(capabilities, 'capabilities.json')
-        sh "tox -e py27"
-      }
-      post {
-        always {
-          archiveArtifacts 'results/*'
-          junit 'results/*.xml'
-          submitToActiveData('results/py27_raw.txt')
-          submitToTreeherder('fxapom', 'T', 'Tests', 'results/*', 'results/py27_tbpl.txt')
-          publishHTML(target: [
-            allowMissing: false,
-            alwaysLinkToLastBuild: true,
-            keepAll: true,
-            reportDir: 'results',
-            reportFiles: "py27.html",
-            reportName: 'HTML Report'])
+      parallel {
+        stage('py36') {
+          agent {
+            dockerfile true
+          }
+          steps {
+            writeCapabilities(capabilities, 'capabilities.json')
+            sh "tox -e py36"
+          }
+          post {
+            always {
+              stash includes: 'results/py36.html', name: 'py36'
+              archiveArtifacts 'results/*'
+              junit 'results/*.xml'
+            }
+          }
+        }
+        stage('py27') {
+          agent {
+            dockerfile true
+          }
+          steps {
+            writeCapabilities(capabilities, 'capabilities.json')
+            sh "tox -e py27"
+          }
+          post {
+            always {
+              stash includes: 'results/py27.html', name: 'py27'
+              archiveArtifacts 'results/*'
+              junit 'results/*.xml'
+              submitToActiveData('results/py27_raw.txt')
+              submitToTreeherder('fxapom', 'T', 'Tests', 'results/*', 'results/py27_tbpl.txt')
+            }
+          }
         }
       }
     }
   }
   post {
+    always {
+      unstash 'py36'
+      unstash 'py27'
+      publishHTML(target: [
+        allowMissing: false,
+        alwaysLinkToLastBuild: true,
+        keepAll: true,
+        reportDir: 'results',
+        reportFiles: "py36.html, py27.html",
+        reportName: 'HTML Report'])
+    }
+    changed {
+      ircNotification()
+    }
     failure {
       emailext(
         attachLog: true,
-        attachmentsPattern: 'results/py27.html',
+        attachmentsPattern: 'results/*.html',
         body: '$BUILD_URL\n\n$FAILED_TESTS',
         replyTo: '$DEFAULT_REPLYTO',
         subject: '$DEFAULT_SUBJECT',
         to: '$DEFAULT_RECIPIENTS')
-    }
-    changed {
-      ircNotification()
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,9 @@ def capabilities = [
 ]
 
 pipeline {
-  agent any
+  agent {
+    dockerfile true
+  }
   libraries {
     lib('fxtest@1.9')
   }

--- a/README.rst
+++ b/README.rst
@@ -96,8 +96,15 @@ Contributing
 ------------
 
 Fork the repository and submit PRs with bug fixes and enhancements,
-contributions are very welcome. Tests can be run locally with
-`tox <http://tox.readthedocs.io/en/latest/>`_.
+contributions are very welcome. You can run the tests using
+`Docker <https://www.docker.com/>`_:
+
+.. code-block:: bash
+
+  $ docker build -t fxapom .
+  $ docker run -it fxapom tox
+
+Using
 
 Resources
 ---------

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,8 @@
 envlist = py{27,36}, flake8
 
 [testenv]
-passenv = BUILD_NUMBER DISPLAY GIT_BRANCH GIT_COMMIT GIT_URL JENKINS_URL \
-    JOB_NAME PYTEST_ADDOPTS PYTEST_BASE_URL SAUCELABS_USR \
-    SAUCELABS_PSW
+passenv = HOME DISPLAY MOZ_HEADLESS PYTEST_ADDOPTS PYTEST_BASE_URL \
+    SAUCELABS_USR SAUCELABS_PSW JENKINS_URL JOB_NAME BUILD_NUMBER
 deps = -rrequirements/{envname}-tests.txt
 commands = pytest \
     --junit-xml=results/{envname}.xml \

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,14 @@ skip_install = true
 deps = -rrequirements/flake8.txt
 commands = flake8 {posargs:.}
 
+[testenv:py27]
+commands = pytest \
+    --junit-xml=results/{envname}.xml \
+    --html=results/{envname}.html --self-contained-html \
+    --log-raw=results/{envname}_raw.txt \
+    --log-tbpl=results/{envname}_tbpl.txt \
+    {posargs:tests}
+
 [flake8]
 ignore = E501
 


### PR DESCRIPTION
This changes our pipeline to build and use a Docker container. This means we don't need to have Python or tox installed on the Jenkins agents, and can determine the version of Python/tox ourselves. It also means contributors don't need to have these dependencies installed.