### PR TITLE
Move isort configuration to tox.ini

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,0 @@
-[isort]
-default_section = THIRDPARTY
-known_first_party = fxapom
-skip = build, .tox

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,11 @@ commands = flake8 {posargs:.}
 [flake8]
 ignore = E501
 
+[isort]
+default_section = THIRDPARTY
+known_first_party = fxapom
+skip = build, .tox
+
 [pytest]
 addopts = -n=auto --verbose -r=a --driver=Firefox
 testpaths = tests


### PR DESCRIPTION
flake8-isort 2.3 supports tox.ini for configuration so we can consolidate.